### PR TITLE
Remove package prefix on NodeType string

### DIFF
--- a/src/main/java/com/example/p2pSim/Leecher.java
+++ b/src/main/java/com/example/p2pSim/Leecher.java
@@ -6,7 +6,7 @@ public class Leecher extends PeerNode {
     }
 
     public String getNodeType() {
-        return "com.example.p2pSim.Leecher";
+        return "Leecher";
     }
 
     public void downloadFrom(PeerNode peer) {

--- a/src/main/java/com/example/p2pSim/Seeder.java
+++ b/src/main/java/com/example/p2pSim/Seeder.java
@@ -10,6 +10,6 @@ public class Seeder extends PeerNode {
     }
 
     public String getNodeType() {
-        return "com.example.p2pSim.Seeder";
+        return "Seeder";
     }
 }

--- a/src/main/java/com/example/p2pSim/SimulationController.java
+++ b/src/main/java/com/example/p2pSim/SimulationController.java
@@ -35,6 +35,8 @@ public class SimulationController {
                 peer = new Leecher(i, x, y, totalChunks);
             }
 
+            System.out.printf("Created Peer %d: %s\n", peer.getId(), peer.getNodeType());
+
             allPeers.add(peer);
         }
 

--- a/src/main/java/com/example/p2pSim/Supernode.java
+++ b/src/main/java/com/example/p2pSim/Supernode.java
@@ -8,7 +8,7 @@ public class Supernode extends PeerNode {
     }
 
     public String getNodeType() {
-        return "com.example.p2pSim.Supernode";
+        return "Supernode";
     }
 
     public boolean canAcceptMoreConnections() {


### PR DESCRIPTION
Network nodes were not properly created with their respective fill color based on the node type. Removing the package prefix on each string return of the getNodeType() getter method fixes this issue and should resolve #1.

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/e8c27d43-ee94-4408-84d6-502695700dc8" />
