### PR TITLE
distinguish-tracked

### DIFF
--- a/src/main/java/org/derekn/p2pSim/SimulationController.java
+++ b/src/main/java/org/derekn/p2pSim/SimulationController.java
@@ -41,7 +41,7 @@ public class SimulationController {
         }
 
         // Assign download target for tracking (e.g., last peer)
-        downloadTarget = allPeers.get(allPeers.size() - 1);
+        downloadTarget = allPeers.getLast();
 
         // Randomly connect peers
         connectPeersRandomly();

--- a/src/main/java/org/derekn/p2pSim/SimulationView.java
+++ b/src/main/java/org/derekn/p2pSim/SimulationView.java
@@ -79,6 +79,10 @@ public class SimulationView extends Pane {
             circle.setStroke(Color.WHITE);
             circle.setStrokeWidth(1.0);
 
+            if (peer == controller.getDownloadTarget()) {
+                circle.setFill(Color.HOTPINK);
+            }
+
             this.getChildren().add(circle);
             nodeCircles.put(peer.getId(), circle);
 


### PR DESCRIPTION
Overrides the client peer node with a unique color upon initial creation. Resolves #12.